### PR TITLE
Fixed broken installation.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include RELEASES
+include README.rst


### PR DESCRIPTION
You lost to add 'README.rst' in package and this broke installation process with pip (or virtualenv):

```
$ sudo pip install pyga 
Downloading/unpacking pyga
Creating supposed download cache at /tmp/.pip/cache
Downloading pyga-2.4.tar.gz
Storing download in cache at /tmp/.pip/cache/http%3A%2F%2Fpypi.python.org%2Fpackages%2Fsource%2Fp%2Fpyga%2Fpyga-2.4.tar.gz
Running setup.py egg_info for package pyga
    Traceback (most recent call last):
    File "<string>", line 14, in <module>
    File "/home/klen/Projects/intaxi/viktortherobot/master/source/build/pyga/setup.py", line 9, in <module>
        long_desc = open(README).read() + '\n\n'
    IOError: [Errno 2] No such file or directory: '/home/klen/Projects/intaxi/viktortherobot/master/source/build/pyga/README.rst'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

File "<string>", line 14, in <module>

File "/home/klen/Projects/intaxi/viktortherobot/master/source/build/pyga/setup.py", line 9, in <module>

    long_desc = open(README).read() + '\n\n'

IOError: [Errno 2] No such file or directory: '/home/klen/Projects/intaxi/viktortherobot/master/source/build/pyga/README.rst'
```
