### PR TITLE
Remove the namespace declaration

### DIFF
--- a/pyga/__init__.py
+++ b/pyga/__init__.py
@@ -1,5 +1,3 @@
-__import__('pkg_resources').declare_namespace(__name__)
-
 from pyga.requests import Q
 
 def shutdown():

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(name='pyga',
       requires=[],
       install_requires=['setuptools', ],
       packages=find_packages(),
-      namespace_packages=['pyga'],
       classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
After installing the package via pip, the **init**.py from the source
distribution does not exist. It is instead replaced by:

  pyga-2.4.2-py2.7-nspkg.pth

Which does some magic to make sure that sys.modules is updated correctly

I am installing pyga and deploying it to appspot and the import fails
because **init**.py is missing.
