### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,9 @@ PYGA: Python Google Analytics - Data Collection API
 .. image:: https://secure.travis-ci.org/kra3/py-ga-mob.png?branch=master
    :alt: Build Status
    :target: http://travis-ci.org/kra3/py-ga-mob
-.. image:: https://pypip.in/v/pyga/badge.png
+.. image:: https://img.shields.io/pypi/v/pyga.svg
    :target: https://crate.io/packages/pyga
-.. image:: https://pypip.in/d/pyga/badge.png
+.. image:: https://img.shields.io/pypi/dm/pyga.svg
    :target: https://crate.io/packages/pyga
 
 pyga is an iplementation of Google Analytics (ga.js) in Python;so that it can be used at server side.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pyga-fc))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pyga-fc`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.