### PR TITLE
docs: fix simple typo, acessed -> accessed

### DIFF
--- a/tests/serialize.py
+++ b/tests/serialize.py
@@ -11,7 +11,7 @@ class TestSerialize(unittest.TestCase):
     def test_unique_id_must_be_equals(self):
         """
         This will test if the unique_id is equals after deserialization
-        even if it is not acessed before serialization
+        even if it is not accessed before serialization
         """
         from pyga.requests import Visitor
 


### PR DESCRIPTION
There is a small typo in tests/serialize.py.

Should read `accessed` rather than `acessed`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md